### PR TITLE
Add hex color tuple parsing and channel reorder helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,158 @@ static_assert(dvalues[1] == -25.0);
 static_assert(dvalues[2] == 3.125);
 ```
 
+## `parse_hex_rgb` / `parse_hex_rgba`（hex color → RGB/RGBAタプル）
+
+`parse_hex_rgb(...)` は RGB 色文字列を、
+`parse_hex_rgba(...)` は RGBA 色文字列を、
+それぞれ `std::tuple` に変換します。
+
+- `parse_hex_rgb(...)` は **`#RGB` / `#RRGGBB`**
+- `parse_hex_rgba(...)` は **`#RGBA` / `#RRGGBBAA`**
+- `to_bgr(...)` は `(r, g, b)` を `(b, g, r)` に並び替えます
+- `to_bgra(...)` は `(r, g, b, a)` を `(b, g, r, a)` に並び替えます
+- `to_abgr(...)` は `(r, g, b, a)` を `(a, b, g, r)` に並び替えます
+- 短縮形は CSS と同じく各 nibble を複製します
+  - `#532` → `#553322`
+  - `#5a3c` → `#55aa33cc`
+- 返り値はそれぞれ `(r, g, b)`、`(r, g, b, a)` の順
+- 不正な入力は、ランタイムでは `std::invalid_argument`、定数評価ではエラーになります
+
+```cpp
+#include "frozenchars.hpp"
+#include <tuple>
+
+using namespace frozenchars;
+
+auto constexpr rgb = parse_hex_rgb("#335577");
+auto constexpr short_rgb = parse_hex_rgb("#532");
+auto constexpr rgba = parse_hex_rgba("#5a3c");
+auto constexpr bgr = to_bgr(rgb);
+auto constexpr bgra = to_bgra(rgba);
+auto constexpr abgr = to_abgr(rgba);
+
+auto constexpr [r, g, b] = rgb;
+auto constexpr [sr, sg, sb] = short_rgb;
+auto constexpr [rr, rg, rb, ra] = rgba;
+auto constexpr [blue, green, red] = bgr;
+auto constexpr [bb, bg, br, ba] = bgra;
+auto constexpr [aa, ab, ag, ar] = abgr;
+
+static_assert(r == 0x33);
+static_assert(g == 0x55);
+static_assert(b == 0x77);
+static_assert(sr == 0x55);
+static_assert(sg == 0x33);
+static_assert(sb == 0x22);
+static_assert(rr == 0x55);
+static_assert(rg == 0xaa);
+static_assert(rb == 0x33);
+static_assert(ra == 0xcc);
+static_assert(blue == 0x77);
+static_assert(green == 0x55);
+static_assert(red == 0x33);
+static_assert(bb == 0x33);
+static_assert(bg == 0xaa);
+static_assert(br == 0x55);
+static_assert(ba == 0xcc);
+static_assert(aa == 0xcc);
+static_assert(ab == 0x33);
+static_assert(ag == 0xaa);
+static_assert(ar == 0x55);
+```
+
+集成体や任意のクラスへの初期化にも使えます。
+
+```cpp
+#include "frozenchars.hpp"
+#include <tuple>
+
+using namespace frozenchars;
+
+struct AggregateColor {
+  std::uint8_t r;
+  std::uint8_t g;
+  std::uint8_t b;
+};
+
+struct AggregateColorA {
+  std::uint8_t r;
+  std::uint8_t g;
+  std::uint8_t b;
+  std::uint8_t a;
+};
+
+struct AggregateColorBgr {
+  std::uint8_t b;
+  std::uint8_t g;
+  std::uint8_t r;
+};
+
+struct LibraryColor {
+  std::uint8_t r;
+  std::uint8_t g;
+  std::uint8_t b;
+
+  constexpr LibraryColor(std::uint8_t red, std::uint8_t green, std::uint8_t blue)
+  : r(red), g(green), b(blue)
+  {}
+};
+
+struct LibraryColorA {
+  std::uint8_t r;
+  std::uint8_t g;
+  std::uint8_t b;
+  std::uint8_t a;
+
+  constexpr LibraryColorA(std::uint8_t red, std::uint8_t green, std::uint8_t blue, std::uint8_t alpha)
+  : r(red), g(green), b(blue), a(alpha)
+  {}
+};
+
+struct LibraryColorAbgr {
+  std::uint8_t a;
+  std::uint8_t b;
+  std::uint8_t g;
+  std::uint8_t r;
+
+  constexpr LibraryColorAbgr(std::uint8_t alpha, std::uint8_t blue, std::uint8_t green, std::uint8_t red)
+  : a(alpha), b(blue), g(green), r(red)
+  {}
+};
+
+auto constexpr aggregate = std::apply(
+  [](auto... channels) constexpr {
+    return AggregateColor{channels...};
+  },
+  parse_hex_rgb("#123")
+);
+
+auto constexpr aggregate_a = std::apply(
+  [](auto... channels) constexpr {
+    return AggregateColorA{channels...};
+  },
+  parse_hex_rgba("#1234")
+);
+
+auto constexpr aggregate_bgr = std::apply(
+  [](auto... channels) constexpr {
+    return AggregateColorBgr{channels...};
+  },
+  to_bgr(parse_hex_rgb("#abcdef"))
+);
+
+auto constexpr color = std::make_from_tuple<LibraryColor>(parse_hex_rgb("#abcdef"));
+auto constexpr color_a = std::make_from_tuple<LibraryColorA>(parse_hex_rgba("#abcdef99"));
+auto constexpr color_abgr = std::make_from_tuple<LibraryColorAbgr>(to_abgr(parse_hex_rgba("#12345678")));
+
+static_assert(aggregate.r == 0x11);
+static_assert(color.g == 0xcd);
+static_assert(aggregate_a.a == 0x44);
+static_assert(color_a.a == 0x99);
+static_assert(aggregate_bgr.b == 0xef);
+static_assert(color_abgr.a == 0x78);
+```
+
 ## `capitalize`（先頭大文字化）
 
 先頭の文字を大文字、残りを小文字に変換します。`FrozenString` と文字列リテラルの両方を受け取ります。

--- a/frozenchars.hpp
+++ b/frozenchars.hpp
@@ -1,17 +1,19 @@
 #ifndef __FROZEN_CHARS_H__
 #define __FROZEN_CHARS_H__
 
-#include <cstddef>
 #include <array>
-#include <span>
-#include <vector>
-#include <string_view>
 #include <algorithm>
 #include <concepts>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
-#include <stdexcept>
-#include <type_traits>
 #include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <type_traits>
+#include <tuple>
+#include <vector>
 
 namespace frozenchars {
 
@@ -404,6 +406,62 @@ namespace detail {
   }
 
   /**
+   * @brief ASCII の16進数字かどうかを判定する関数
+   *
+   * @param c 判定する文字
+   * @return auto constexpr 16進数字なら true
+   */
+  auto constexpr is_hex_digit(char c) noexcept {
+    return (c >= '0' && c <= '9')
+      || (c >= 'a' && c <= 'f')
+      || (c >= 'A' && c <= 'F');
+  }
+
+  /**
+   * @brief 16進数字1文字を 0..15 に変換する関数
+   *
+   * @param c 変換する16進数字
+   * @return auto constexpr 変換結果
+   */
+  auto constexpr hex_digit_to_value(char c) {
+    if (c >= '0' && c <= '9') {
+      return static_cast<std::uint8_t>(c - '0');
+    }
+    if (c >= 'a' && c <= 'f') {
+      return static_cast<std::uint8_t>(10 + (c - 'a'));
+    }
+    if (c >= 'A' && c <= 'F') {
+      return static_cast<std::uint8_t>(10 + (c - 'A'));
+    }
+    throw std::invalid_argument("parse_hex_color: invalid hex digit");
+  }
+
+  /**
+   * @brief 16進数字2文字を 1byte に変換する関数
+   *
+   * @param hi 上位4bitを表す16進数字
+   * @param lo 下位4bitを表す16進数字
+   * @return auto constexpr 変換結果
+   */
+  auto constexpr parse_hex_byte(char hi, char lo) {
+    if (!is_hex_digit(hi) || !is_hex_digit(lo)) {
+      throw std::invalid_argument("parse_hex_color: invalid hex digit");
+    }
+    return static_cast<std::uint8_t>((hex_digit_to_value(hi) << 4u) | hex_digit_to_value(lo));
+  }
+
+  /**
+   * @brief 16進数字1文字を nibble 複製して 1byte に変換する関数
+   *
+   * @param c 変換する16進数字
+   * @return auto constexpr 変換結果
+   */
+  auto constexpr parse_hex_shorthand_byte(char c) {
+    auto const value = hex_digit_to_value(c);
+    return static_cast<std::uint8_t>((value << 4u) | value);
+  }
+
+  /**
    * @brief 区切り判定関数でトークン数を数える関数
    *
    * @tparam IsDelimiter 区切り文字判定関数（デフォルト: 空白判定）
@@ -783,6 +841,128 @@ template <Numeric Int, size_t N>
   requires (!std::same_as<std::remove_cv_t<Int>, bool>)
 auto constexpr split_numbers(char const (&str)[N]) {
   return split_numbers<detail::is_whitespace, Int>(FrozenString{str});
+}
+
+/**
+ * @brief `#RGB` / `#RRGGBB` 形式の色文字列を RGB タプルへ変換する関数
+ *
+ * @param str 対象文字列
+ * @return auto constexpr `(r, g, b)` の順に並んだタプル
+ */
+auto constexpr parse_hex_rgb(std::string_view str) {
+  if (str.empty() || str[0] != '#' || (str.size() != 4 && str.size() != 7)) {
+    throw std::invalid_argument("parse_hex_rgb: expected #RGB or #RRGGBB");
+  }
+
+  if (str.size() == 4) {
+    return std::tuple{
+      detail::parse_hex_shorthand_byte(str[1]),
+      detail::parse_hex_shorthand_byte(str[2]),
+      detail::parse_hex_shorthand_byte(str[3])
+    };
+  }
+
+  return std::tuple{
+    detail::parse_hex_byte(str[1], str[2]),
+    detail::parse_hex_byte(str[3], str[4]),
+    detail::parse_hex_byte(str[5], str[6])
+  };
+}
+
+/**
+ * @brief 文字列リテラル版の `#RGB` / `#RRGGBB` パーサ
+ *
+ * @tparam N 文字列リテラルの長さ (終端文字'\0'を含む)
+ * @param str 対象文字列リテラル
+ * @return auto constexpr `(r, g, b)` の順に並んだタプル
+ */
+template <size_t N>
+auto constexpr parse_hex_rgb(char const (&str)[N]) {
+  return parse_hex_rgb(std::string_view{str, N - 1});
+}
+
+/**
+ * @brief `#RGBA` / `#RRGGBBAA` 形式の色文字列を RGBA タプルへ変換する関数
+ *
+ * @param str 対象文字列
+ * @return auto constexpr `(r, g, b, a)` の順に並んだタプル
+ */
+auto constexpr parse_hex_rgba(std::string_view str) {
+  if (str.empty() || str[0] != '#' || (str.size() != 5 && str.size() != 9)) {
+    throw std::invalid_argument("parse_hex_rgba: expected #RGBA or #RRGGBBAA");
+  }
+
+  if (str.size() == 5) {
+    return std::tuple{
+      detail::parse_hex_shorthand_byte(str[1]),
+      detail::parse_hex_shorthand_byte(str[2]),
+      detail::parse_hex_shorthand_byte(str[3]),
+      detail::parse_hex_shorthand_byte(str[4])
+    };
+  }
+
+  return std::tuple{
+    detail::parse_hex_byte(str[1], str[2]),
+    detail::parse_hex_byte(str[3], str[4]),
+    detail::parse_hex_byte(str[5], str[6]),
+    detail::parse_hex_byte(str[7], str[8])
+  };
+}
+
+/**
+ * @brief 文字列リテラル版の `#RGBA` / `#RRGGBBAA` パーサ
+ *
+ * @tparam N 文字列リテラルの長さ (終端文字'\0'を含む)
+ * @param str 対象文字列リテラル
+ * @return auto constexpr `(r, g, b, a)` の順に並んだタプル
+ */
+template <size_t N>
+auto constexpr parse_hex_rgba(char const (&str)[N]) {
+  return parse_hex_rgba(std::string_view{str, N - 1});
+}
+
+/**
+ * @brief RGB タプルを BGR タプルへ並び替える関数
+ *
+ * @tparam R 赤チャネル型
+ * @tparam G 緑チャネル型
+ * @tparam B 青チャネル型
+ * @param rgb `(r, g, b)` の順のタプル
+ * @return auto constexpr `(b, g, r)` の順のタプル
+ */
+template <typename R, typename G, typename B>
+auto constexpr to_bgr(std::tuple<R, G, B> const& rgb) {
+  return std::tuple<B, G, R>{std::get<2>(rgb), std::get<1>(rgb), std::get<0>(rgb)};
+}
+
+/**
+ * @brief RGBA タプルを BGRA タプルへ並び替える関数
+ *
+ * @tparam R 赤チャネル型
+ * @tparam G 緑チャネル型
+ * @tparam B 青チャネル型
+ * @tparam A アルファチャネル型
+ * @param rgba `(r, g, b, a)` の順のタプル
+ * @return auto constexpr `(b, g, r, a)` の順のタプル
+ */
+template <typename R, typename G, typename B, typename A>
+auto constexpr to_bgra(std::tuple<R, G, B, A> const& rgba) {
+  return std::tuple<B, G, R, A>{std::get<2>(rgba), std::get<1>(rgba), std::get<0>(rgba), std::get<3>(rgba)};
+}
+
+/**
+ * @brief RGBA タプルを ABGR タプルへ並び替える関数
+ *
+ * @tparam R 赤チャネル型
+ * @tparam G 緑チャネル型
+ * @tparam B 青チャネル型
+ * @tparam A アルファチャネル型
+ * @param rgba `(r, g, b, a)` の順のタプル
+ * @return auto constexpr `(a, b, g, r)` の順のタプル
+ */
+template <typename R, typename G, typename B, typename A>
+auto constexpr to_abgr(std::tuple<R, G, B, A> const& rgba) {
+  return std::tuple<A, B, G, R>{std::get<3>(rgba), std::get<2>(rgba), std::get<1>(rgba), std::get<0>(rgba)};
 }
 
 /**

--- a/test/test_runtime.cpp
+++ b/test/test_runtime.cpp
@@ -2,6 +2,8 @@
 
 #include "frozenchars.hpp"
 
+#include <tuple>
+
 using namespace frozenchars;
 using namespace frozenchars::literals;
 
@@ -132,4 +134,71 @@ TEST_CASE("freeze truncates long std::vector<std::byte>") {
   auto const s = freeze(big);
   REQUIRE(s.sv().size() == 256);
   REQUIRE(std::all_of(s.sv().begin(), s.sv().end(), [](char c) { return c == 'z'; }));
+}
+
+TEST_CASE("parse_hex_rgb parses runtime values") {
+  auto const rgb = parse_hex_rgb("#335577");
+  REQUIRE(std::get<0>(rgb) == 0x33);
+  REQUIRE(std::get<1>(rgb) == 0x55);
+  REQUIRE(std::get<2>(rgb) == 0x77);
+
+  auto const short_rgb = parse_hex_rgb("#532");
+  REQUIRE(std::get<0>(short_rgb) == 0x55);
+  REQUIRE(std::get<1>(short_rgb) == 0x33);
+  REQUIRE(std::get<2>(short_rgb) == 0x22);
+}
+
+TEST_CASE("parse_hex_rgb rejects invalid length at runtime") {
+  REQUIRE_THROWS_AS(parse_hex_rgb("#33557"), std::invalid_argument);
+  REQUIRE_THROWS_AS(parse_hex_rgb("335577"), std::invalid_argument);
+  REQUIRE_THROWS_AS(parse_hex_rgb("#33557cc"), std::invalid_argument);
+}
+
+TEST_CASE("parse_hex_rgb rejects invalid digits at runtime") {
+  REQUIRE_THROWS_AS(parse_hex_rgb("#33GG77"), std::invalid_argument);
+  REQUIRE_THROWS_AS(parse_hex_rgb("#5g2"), std::invalid_argument);
+}
+
+TEST_CASE("parse_hex_rgba parses runtime values") {
+  auto const rgba = parse_hex_rgba("#335577cc");
+  REQUIRE(std::get<0>(rgba) == 0x33);
+  REQUIRE(std::get<1>(rgba) == 0x55);
+  REQUIRE(std::get<2>(rgba) == 0x77);
+  REQUIRE(std::get<3>(rgba) == 0xcc);
+
+  auto const short_rgba = parse_hex_rgba("#5a3c");
+  REQUIRE(std::get<0>(short_rgba) == 0x55);
+  REQUIRE(std::get<1>(short_rgba) == 0xaa);
+  REQUIRE(std::get<2>(short_rgba) == 0x33);
+  REQUIRE(std::get<3>(short_rgba) == 0xcc);
+}
+
+TEST_CASE("parse_hex_rgba rejects invalid length at runtime") {
+  REQUIRE_THROWS_AS(parse_hex_rgba("#335577"), std::invalid_argument);
+  REQUIRE_THROWS_AS(parse_hex_rgba("#335577c"), std::invalid_argument);
+  REQUIRE_THROWS_AS(parse_hex_rgba("335577cc"), std::invalid_argument);
+}
+
+TEST_CASE("parse_hex_rgba rejects invalid digits at runtime") {
+  REQUIRE_THROWS_AS(parse_hex_rgba("#33GG77cc"), std::invalid_argument);
+  REQUIRE_THROWS_AS(parse_hex_rgba("#5a3z"), std::invalid_argument);
+}
+
+TEST_CASE("tuple channel reorder helpers reorder runtime tuples") {
+  auto const bgr = to_bgr(parse_hex_rgb("#123456"));
+  REQUIRE(std::get<0>(bgr) == 0x56);
+  REQUIRE(std::get<1>(bgr) == 0x34);
+  REQUIRE(std::get<2>(bgr) == 0x12);
+
+  auto const bgra = to_bgra(parse_hex_rgba("#12345678"));
+  REQUIRE(std::get<0>(bgra) == 0x56);
+  REQUIRE(std::get<1>(bgra) == 0x34);
+  REQUIRE(std::get<2>(bgra) == 0x12);
+  REQUIRE(std::get<3>(bgra) == 0x78);
+
+  auto const abgr = to_abgr(parse_hex_rgba("#12345678"));
+  REQUIRE(std::get<0>(abgr) == 0x78);
+  REQUIRE(std::get<1>(abgr) == 0x56);
+  REQUIRE(std::get<2>(abgr) == 0x34);
+  REQUIRE(std::get<3>(abgr) == 0x12);
 }

--- a/test/test_simple.cpp
+++ b/test/test_simple.cpp
@@ -1,5 +1,7 @@
 #include "catch2/catch_all.hpp"
 
+#include <tuple>
+
 #include "frozenchars.hpp"
 
 using namespace frozenchars;
@@ -393,6 +395,201 @@ TEST_CASE("split_numbers with floating-point type") {
   REQUIRE_THROWS_AS(split_numbers<float>("1.0.0"), std::invalid_argument);
   REQUIRE_THROWS_AS(split_numbers<float>("1e"), std::invalid_argument);
   REQUIRE_THROWS_AS(split_numbers<float>("1e999"), std::out_of_range);
+}
+
+TEST_CASE("parse_hex_rgb constexpr") {
+  auto constexpr rgb = parse_hex_rgb("#335577");
+  static_assert(std::get<0>(rgb) == 0x33);
+  static_assert(std::get<1>(rgb) == 0x55);
+  static_assert(std::get<2>(rgb) == 0x77);
+  REQUIRE(std::get<0>(rgb) == 0x33);
+  REQUIRE(std::get<1>(rgb) == 0x55);
+  REQUIRE(std::get<2>(rgb) == 0x77);
+
+  auto constexpr mixed = parse_hex_rgb("#aBcDeF");
+  static_assert(std::get<0>(mixed) == 0xab);
+  static_assert(std::get<1>(mixed) == 0xcd);
+  static_assert(std::get<2>(mixed) == 0xef);
+  REQUIRE(std::get<0>(mixed) == 0xab);
+  REQUIRE(std::get<1>(mixed) == 0xcd);
+  REQUIRE(std::get<2>(mixed) == 0xef);
+
+  auto constexpr short_rgb = parse_hex_rgb("#532");
+  static_assert(std::get<0>(short_rgb) == 0x55);
+  static_assert(std::get<1>(short_rgb) == 0x33);
+  static_assert(std::get<2>(short_rgb) == 0x22);
+  REQUIRE(std::get<0>(short_rgb) == 0x55);
+  REQUIRE(std::get<1>(short_rgb) == 0x33);
+  REQUIRE(std::get<2>(short_rgb) == 0x22);
+}
+
+TEST_CASE("parse_hex_rgb can initialize user color types") {
+  struct RgbAggregate {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+  };
+
+  struct RgbClass {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+
+    constexpr RgbClass(std::uint8_t red, std::uint8_t green, std::uint8_t blue) noexcept
+    : r(red), g(green), b(blue)
+    {}
+  };
+
+  auto constexpr aggregate = std::apply([](auto... channels) constexpr {
+    return RgbAggregate{channels...};
+  }, parse_hex_rgb("#123456"));
+  static_assert(aggregate.r == 0x12);
+  static_assert(aggregate.g == 0x34);
+  static_assert(aggregate.b == 0x56);
+  REQUIRE(aggregate.r == 0x12);
+  REQUIRE(aggregate.g == 0x34);
+  REQUIRE(aggregate.b == 0x56);
+
+  auto constexpr color = std::make_from_tuple<RgbClass>(parse_hex_rgb("#abcdef"));
+  static_assert(color.r == 0xab);
+  static_assert(color.g == 0xcd);
+  static_assert(color.b == 0xef);
+  REQUIRE(color.r == 0xab);
+  REQUIRE(color.g == 0xcd);
+  REQUIRE(color.b == 0xef);
+}
+
+TEST_CASE("parse_hex_rgba constexpr") {
+  auto constexpr rgba = parse_hex_rgba("#335577cc");
+  static_assert(std::get<0>(rgba) == 0x33);
+  static_assert(std::get<1>(rgba) == 0x55);
+  static_assert(std::get<2>(rgba) == 0x77);
+  static_assert(std::get<3>(rgba) == 0xcc);
+  REQUIRE(std::get<0>(rgba) == 0x33);
+  REQUIRE(std::get<1>(rgba) == 0x55);
+  REQUIRE(std::get<2>(rgba) == 0x77);
+  REQUIRE(std::get<3>(rgba) == 0xcc);
+
+  auto constexpr short_rgba = parse_hex_rgba("#5a3c");
+  static_assert(std::get<0>(short_rgba) == 0x55);
+  static_assert(std::get<1>(short_rgba) == 0xaa);
+  static_assert(std::get<2>(short_rgba) == 0x33);
+  static_assert(std::get<3>(short_rgba) == 0xcc);
+  REQUIRE(std::get<0>(short_rgba) == 0x55);
+  REQUIRE(std::get<1>(short_rgba) == 0xaa);
+  REQUIRE(std::get<2>(short_rgba) == 0x33);
+  REQUIRE(std::get<3>(short_rgba) == 0xcc);
+}
+
+TEST_CASE("parse_hex_rgba can initialize user color types") {
+  struct RgbaAggregate {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+    std::uint8_t a;
+  };
+
+  struct RgbaClass {
+    std::uint8_t r;
+    std::uint8_t g;
+    std::uint8_t b;
+    std::uint8_t a;
+
+    constexpr RgbaClass(std::uint8_t red, std::uint8_t green, std::uint8_t blue, std::uint8_t alpha) noexcept
+    : r(red), g(green), b(blue), a(alpha)
+    {}
+  };
+
+  auto constexpr aggregate = std::apply([](auto... channels) constexpr {
+    return RgbaAggregate{channels...};
+  }, parse_hex_rgba("#1234"));
+  static_assert(aggregate.r == 0x11);
+  static_assert(aggregate.g == 0x22);
+  static_assert(aggregate.b == 0x33);
+  static_assert(aggregate.a == 0x44);
+  REQUIRE(aggregate.r == 0x11);
+  REQUIRE(aggregate.g == 0x22);
+  REQUIRE(aggregate.b == 0x33);
+  REQUIRE(aggregate.a == 0x44);
+
+  auto constexpr color = std::make_from_tuple<RgbaClass>(parse_hex_rgba("#abcdef99"));
+  static_assert(color.r == 0xab);
+  static_assert(color.g == 0xcd);
+  static_assert(color.b == 0xef);
+  static_assert(color.a == 0x99);
+  REQUIRE(color.r == 0xab);
+  REQUIRE(color.g == 0xcd);
+  REQUIRE(color.b == 0xef);
+  REQUIRE(color.a == 0x99);
+}
+
+TEST_CASE("tuple channel reorder helpers are constexpr") {
+  auto constexpr bgr = to_bgr(parse_hex_rgb("#123456"));
+  static_assert(std::get<0>(bgr) == 0x56);
+  static_assert(std::get<1>(bgr) == 0x34);
+  static_assert(std::get<2>(bgr) == 0x12);
+  REQUIRE(std::get<0>(bgr) == 0x56);
+  REQUIRE(std::get<1>(bgr) == 0x34);
+  REQUIRE(std::get<2>(bgr) == 0x12);
+
+  auto constexpr bgra = to_bgra(parse_hex_rgba("#12345678"));
+  static_assert(std::get<0>(bgra) == 0x56);
+  static_assert(std::get<1>(bgra) == 0x34);
+  static_assert(std::get<2>(bgra) == 0x12);
+  static_assert(std::get<3>(bgra) == 0x78);
+  REQUIRE(std::get<0>(bgra) == 0x56);
+  REQUIRE(std::get<1>(bgra) == 0x34);
+  REQUIRE(std::get<2>(bgra) == 0x12);
+  REQUIRE(std::get<3>(bgra) == 0x78);
+
+  auto constexpr abgr = to_abgr(parse_hex_rgba("#1234"));
+  static_assert(std::get<0>(abgr) == 0x44);
+  static_assert(std::get<1>(abgr) == 0x33);
+  static_assert(std::get<2>(abgr) == 0x22);
+  static_assert(std::get<3>(abgr) == 0x11);
+  REQUIRE(std::get<0>(abgr) == 0x44);
+  REQUIRE(std::get<1>(abgr) == 0x33);
+  REQUIRE(std::get<2>(abgr) == 0x22);
+  REQUIRE(std::get<3>(abgr) == 0x11);
+}
+
+TEST_CASE("tuple channel reorder helpers can initialize user color types") {
+  struct BgrColor {
+    std::uint8_t b;
+    std::uint8_t g;
+    std::uint8_t r;
+  };
+
+  struct AbgrColor {
+    std::uint8_t a;
+    std::uint8_t b;
+    std::uint8_t g;
+    std::uint8_t r;
+
+    constexpr AbgrColor(std::uint8_t alpha, std::uint8_t blue, std::uint8_t green, std::uint8_t red) noexcept
+    : a(alpha), b(blue), g(green), r(red)
+    {}
+  };
+
+  auto constexpr aggregate = std::apply([](auto... channels) constexpr {
+    return BgrColor{channels...};
+  }, to_bgr(parse_hex_rgb("#abcdef")));
+  static_assert(aggregate.b == 0xef);
+  static_assert(aggregate.g == 0xcd);
+  static_assert(aggregate.r == 0xab);
+  REQUIRE(aggregate.b == 0xef);
+  REQUIRE(aggregate.g == 0xcd);
+  REQUIRE(aggregate.r == 0xab);
+
+  auto constexpr color = std::make_from_tuple<AbgrColor>(to_abgr(parse_hex_rgba("#12345678")));
+  static_assert(color.a == 0x78);
+  static_assert(color.b == 0x56);
+  static_assert(color.g == 0x34);
+  static_assert(color.r == 0x12);
+  REQUIRE(color.a == 0x78);
+  REQUIRE(color.b == 0x56);
+  REQUIRE(color.g == 0x34);
+  REQUIRE(color.r == 0x12);
 }
 
 TEST_CASE("capitalize") {


### PR DESCRIPTION
## Summary
- add constexpr hex color parsers for #RGB/#RRGGBB and #RGBA/#RRGGBBAA
- add tuple channel reorder helpers: to_bgr, to_bgra, and to_abgr
- add README examples and compile-time/runtime tests covering parsing and tuple-based color initialization

## Test Plan
- [x] ./build.sh
- [x] ./test.sh